### PR TITLE
fix: return a JSON-RPC formatted 404 error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
 import rpc from './rpc';
+import { rpcError } from './utils';
 
 const app = express();
 const PORT = process.env.PORT ?? 3003;
@@ -10,5 +11,9 @@ app.use(express.json({ limit: '8mb' }));
 app.use(express.urlencoded({ limit: '8mb', extended: false }));
 app.use(cors({ maxAge: 86400 }));
 app.use('/', rpc);
+
+app.use((req, res) => {
+  rpcError(res, 404, {}, req.body.id);
+});
 
 app.listen(PORT, () => console.log(`Listening at http://localhost:${PORT}`));


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

404 errors are returned with Express default handler, as a HTML response. All other errors are using JSON-RPC, 404 is the only one using another response type

## 💊 Fixes / Solution

Use JSON-RPC formatted response for 404 errors

## 🚧 Changes

- Add catch-all routes, to return a JSON-RPC response on 404 errors

## 🛠️ Tests
 
- Run `yarn dev`
- Open `localhost:3003/test-test`
- It should return a JSON response, instead of express default error
