### PR TITLE
fix: fix error when eth address is invalid

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,13 +11,13 @@ export default {
   coverageProvider: 'v8',
 
   // An array of regexp pattern strings used to skip coverage collection
-  coveragePathIgnorePatterns: ['/node_modules/', '<rootDir>/dist/', '<rootDir>/test/fixtures/'],
+  coveragePathIgnorePatterns: ['/node_modules/', '<rootDir>/build/', '<rootDir>/test/fixtures/'],
 
   preset: 'ts-jest',
   testEnvironment: 'jest-environment-node-single-context',
   setupFiles: ['dotenv/config'],
   //setupFilesAfterEnv: ['<rootDir>src/setupTests.ts'],
   moduleFileExtensions: ['js', 'ts'],
-  testPathIgnorePatterns: ['dist/'],
+  testPathIgnorePatterns: ['build/'],
   verbose: true
 };

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.18.0",
+    "@ethersproject/address": "^5.7.0",
     "@snapshot-labs/keycard": "0.2.0",
     "@snapshot-labs/snapshot-metrics": "^1.0.0",
     "@snapshot-labs/snapshot-sentry": "^1.1.0",

--- a/test/e2e/get_vp.test.ts
+++ b/test/e2e/get_vp.test.ts
@@ -1,11 +1,18 @@
 import request from 'supertest';
 
 describe('getVp', () => {
-  describe('when the address params is missing', () => {
-    it('returns a 500 error', async () => {
-      const response = await request(process.env.HOST).post('/').send({ method: 'get_vp' });
+  describe('when the address is invalid', () => {
+    it.each([
+      ['empty address', '0x0000000000000000000000000000000000000000'],
+      ['empty string', ''],
+      ['null', null],
+      ['invalid address', 'test']
+    ])('returns a 400 error on %s', async (title, address) => {
+      const response = await request(process.env.HOST)
+        .post('/')
+        .send({ method: 'get_vp', address });
 
-      expect(response.status).toEqual(500);
+      expect(response.status).toEqual(400);
     });
   });
 

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -1,41 +1,19 @@
 import request from 'supertest';
 
-const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
-
 describe('/', () => {
   describe('when method params is missing', () => {
-    it('returns a 500 error', async () => {
+    it('returns a 400 error', async () => {
       const response = await request(process.env.HOST).post('/').send({});
 
-      expect(response.status).toEqual(500);
+      expect(response.status).toEqual(400);
     });
   });
 
   describe('when method params is invalid', () => {
-    it('returns a 500 error', async () => {
+    it('returns a 400 error', async () => {
       const response = await request(process.env.HOST).post('/').send({ method: 'test' });
 
-      expect(response.status).toEqual(500);
-    });
-  });
-
-  describe('when the address params is blank', () => {
-    it('returns a 500 error', async () => {
-      const response = await request(process.env.HOST)
-        .post('/')
-        .send({ method: 'get_vp', address: EMPTY_ADDRESS });
-
-      expect(response.status).toEqual(500);
-    });
-  });
-
-  describe('when the author params is blank', () => {
-    it('returns a 500 error', async () => {
-      const response = await request(process.env.HOST)
-        .post('/')
-        .send({ method: 'get_vp', author: EMPTY_ADDRESS });
-
-      expect(response.status).toEqual(500);
+      expect(response.status).toEqual(400);
     });
   });
 });

--- a/test/e2e/validate.test.ts
+++ b/test/e2e/validate.test.ts
@@ -1,3 +1,20 @@
+import request from 'supertest';
+
 describe('validate', () => {
+  describe('when the author is invalid', () => {
+    it.each([
+      ['empty address', '0x0000000000000000000000000000000000000000'],
+      ['empty string', ''],
+      ['null', null],
+      ['invalid address', 'test']
+    ])('returns a 400 error on %s', async (title, author) => {
+      const response = await request(process.env.HOST)
+        .post('/')
+        .send({ method: 'validate', author });
+
+      expect(response.status).toEqual(400);
+    });
+  });
+
   it.todo('validates the voting power');
 });


### PR DESCRIPTION
Fix #836 
Fix SCORE-API-22

- Fix error when parsing of the eth address is failing 
- Return a 400 error code when failing because of invalid user input