### PR TITLE
chore: instrument rate limited requests

### DIFF
--- a/src/helpers/rateLimit.ts
+++ b/src/helpers/rateLimit.ts
@@ -1,6 +1,7 @@
 import rateLimit from 'express-rate-limit';
 import RedisStore from 'rate-limit-redis';
 import { createClient } from 'redis';
+import { rateLimitedRequestsCount } from '../metrics';
 import { getIp, rpcError } from '../utils';
 
 let client;
@@ -27,9 +28,11 @@ export default rateLimit({
   skip: (req, res) => {
     const keycardData = res.locals.keycardData;
     if (keycardData?.valid && !keycardData.rateLimited) {
+      rateLimitedRequestsCount.inc({ rate_limited: 1 });
       return true;
     }
 
+    rateLimitedRequestsCount.inc({ rate_limited: 0 });
     return false;
   },
   handler: (req, res) => {

--- a/src/helpers/rateLimit.ts
+++ b/src/helpers/rateLimit.ts
@@ -1,7 +1,6 @@
 import rateLimit from 'express-rate-limit';
 import RedisStore from 'rate-limit-redis';
 import { createClient } from 'redis';
-import { rateLimitedRequestsCount } from '../metrics';
 import { getIp, rpcError } from '../utils';
 
 let client;
@@ -28,11 +27,9 @@ export default rateLimit({
   skip: (req, res) => {
     const keycardData = res.locals.keycardData;
     if (keycardData?.valid && !keycardData.rateLimited) {
-      rateLimitedRequestsCount.inc({ rate_limited: 1 });
       return true;
     }
 
-    rateLimitedRequestsCount.inc({ rate_limited: 0 });
     return false;
   },
   handler: (req, res) => {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,6 +1,12 @@
-import init from '@snapshot-labs/snapshot-metrics';
+import init, { client } from '@snapshot-labs/snapshot-metrics';
 import { Express } from 'express';
 
 export default function initMetrics(app: Express) {
   init(app, { whitelistedPath: [/^\/$/, /^\/api\/(strategies|validations|scores)$/] });
 }
+
+export const rateLimitedRequestsCount = new client.Counter({
+  name: 'http_requests_by_rate_limit_count',
+  help: 'Total number of requests, by rate limit status',
+  labelNames: ['rate_limited']
+});

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,12 +1,26 @@
 import init, { client } from '@snapshot-labs/snapshot-metrics';
 import { Express } from 'express';
 
-export default function initMetrics(app: Express) {
-  init(app, { whitelistedPath: [/^\/$/, /^\/api\/(strategies|validations|scores)$/] });
-}
+const whitelistedPath = [/^\/$/, /^\/api\/(strategies|validations|scores)$/];
 
-export const rateLimitedRequestsCount = new client.Counter({
+const rateLimitedRequestsCount = new client.Counter({
   name: 'http_requests_by_rate_limit_count',
   help: 'Total number of requests, by rate limit status',
   labelNames: ['rate_limited']
 });
+
+function instrumentRateLimitedRequests(req, res, next) {
+  res.on('finish', () => {
+    if (whitelistedPath.some((path) => path.test(req.path))) {
+      rateLimitedRequestsCount.inc({ rate_limited: res.statusCode === 429 ? 1 : 0 });
+    }
+  });
+
+  next();
+}
+
+export default function initMetrics(app: Express) {
+  init(app, { whitelistedPath });
+
+  app.use(instrumentRateLimitedRequests);
+}


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

We have no metrics about how many requests are rate-limited

## 💊 Fixes / Solution

Instrument the rateLimit middleware, and start counting request that are rate limited 

## 🚧 Changes

- Add counters to track number of requests which are not rate limited
- Add counters to track number of requests which are rate limited

## 🛠️ Tests

- `yarn dev`
- Visit some url
- Visit `/metrics`
- There should be a counter in the form: 

```
# HELP http_requests_by_rate_limit_count Total number of requests, by rate limit status
# TYPE http_requests_by_rate_limit_count counter
http_requests_by_rate_limit_count{rate_limited="0"} 2
```