### PR TITLE
feat(strategies): add required env variables to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ KEYCARD_SECRET=
 SENTRY_DSN=
 SENTRY_TRACE_SAMPLE_RATE=
 BROVIDER_URL=https://rpc.snapshot.org
+# @snapshot-labs/strategies - Required env variables
+PASSPORT_API_KEY=
+PASSPORT_SCORER_ID=


### PR DESCRIPTION
### Issues

Related to https://github.com/snapshot-labs/snapshot-strategies/pull/1270

### Changes

1. The `@snapshot-labs/strategies` dependency requires some environment variables for strategies to work. This PR add those environment variables names to `.env.example`