### PR TITLE
fix: Remove rocketpool-dao.eth from disabled list

### DIFF
--- a/src/disabled.json
+++ b/src/disabled.json
@@ -1,1 +1,1 @@
-["revotu.eth", "aitd.eth", "benttest.eth", "rocketpool-dao.eth"]
+["revotu.eth", "aitd.eth", "benttest.eth"]


### PR DESCRIPTION
We've added rocketpool-dao.eth to disabled list because we get lot of traffic 