### PR TITLE
refactor: extract cache logic from `getVp`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,3 +6,5 @@ jobs:
   test:
     uses: snapshot-labs/actions/.github/workflows/test.yml@main
     secrets: inherit
+    with:
+      redis: true

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "node build/src/index.js",
     "test:unit": "jest --config=jest.config.unit.ts",
     "test:unit:watch": "yarn test:unit --watch",
+    "test:integration": "dotenv -e test/.env.test yarn jest --collectCoverage=false test/integration/",
     "start:test": "dotenv -e test/.env.test yarn dev",
     "test": "PORT=3033 start-server-and-test 'yarn start:test' 3033 'dotenv -e test/.env.test jest --runInBand'",
     "test:e2e": "PORT=3033 start-server-and-test 'yarn start:test' 3033 'dotenv -e test/.env.test jest --runInBand --collectCoverage=false test/e2e/'"

--- a/src/helpers/cache.ts
+++ b/src/helpers/cache.ts
@@ -1,11 +1,18 @@
-import snapshot from '@snapshot-labs/strategies';
 import redis from '../redis';
-
-type VpResult = ReturnType<typeof snapshot.utils.getVp>;
 
 const VP_KEY_PREFIX = 'vp';
 
-export async function cachedVp(key: string, callback: () => VpResult, toCache = false) {
+interface VpResult {
+  vp: number;
+  vp_by_strategy?: number[];
+  vp_state: string;
+}
+
+export async function cachedVp<Type extends Promise<VpResult>>(
+  key: string,
+  callback: () => Type,
+  toCache = false
+) {
   if (!toCache || !redis) {
     return { result: await callback(), cache: false };
   }
@@ -16,7 +23,7 @@ export async function cachedVp(key: string, callback: () => VpResult, toCache = 
     cache.vp = parseFloat(cache.vp);
     cache.vp_by_strategy = JSON.parse(cache.vp_by_strategy);
 
-    return { result: cache as Awaited<VpResult>, cache: true };
+    return { result: cache as Awaited<Type>, cache: true };
   }
 
   const result = await callback();

--- a/src/helpers/cache.ts
+++ b/src/helpers/cache.ts
@@ -1,6 +1,6 @@
 import redis from '../redis';
 
-const VP_KEY_PREFIX = 'vp';
+export const VP_KEY_PREFIX = 'vp';
 
 interface VpResult {
   vp: number;
@@ -11,7 +11,7 @@ interface VpResult {
 export async function cachedVp<Type extends Promise<VpResult>>(
   key: string,
   callback: () => Type,
-  toCache = false
+  toCache = true
 ) {
   if (!toCache || !redis) {
     return { result: await callback(), cache: false };

--- a/src/helpers/cache.ts
+++ b/src/helpers/cache.ts
@@ -1,0 +1,33 @@
+import snapshot from '@snapshot-labs/strategies';
+import redis from '../redis';
+
+type VpResult = ReturnType<typeof snapshot.utils.getVp>;
+
+const VP_KEY_PREFIX = 'vp';
+
+export async function cachedVp(key: string, callback: () => VpResult, toCache = false) {
+  if (!toCache || !redis) {
+    return { result: await callback(), cache: false };
+  }
+
+  const cache = await redis.hGetAll(`${VP_KEY_PREFIX}:${key}`);
+
+  if (cache?.vp_state) {
+    cache.vp = parseFloat(cache.vp);
+    cache.vp_by_strategy = JSON.parse(cache.vp_by_strategy);
+
+    return { result: cache as Awaited<VpResult>, cache: true };
+  }
+
+  const result = await callback();
+
+  if (result.vp_state === 'final') {
+    const multi = redis.multi();
+    multi.hSet(`${VP_KEY_PREFIX}:${key}`, 'vp', result.vp);
+    multi.hSet(`${VP_KEY_PREFIX}:${key}`, 'vp_by_strategy', JSON.stringify(result.vp_by_strategy));
+    multi.hSet(`${VP_KEY_PREFIX}:${key}`, 'vp_state', result.vp_state);
+    multi.exec();
+  }
+
+  return { result, cache: false };
+}

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -21,6 +21,8 @@ interface ValidateRequestParams {
   params: any;
 }
 
+type VpResult = ReturnType<typeof snapshot.utils.getVp>;
+
 const disableCachingForSpaces = ['magicappstore.eth', 'moonbeam-foundation.eth'];
 
 export async function getVp(params: GetVpRequestParams) {
@@ -34,7 +36,7 @@ export async function getVp(params: GetVpRequestParams) {
     params.snapshot = currentBlockNum < params.snapshot ? 'latest' : params.snapshot;
   }
 
-  return await cachedVp(
+  return await cachedVp<VpResult>(
     sha256(JSON.stringify(params)),
     async () => {
       return await snapshot.utils.getVp(

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -14,13 +14,15 @@ let client;
   client.on('end', err => console.log('[redis] Redis end', err));
   await client.connect();
 
-  setInterval(async () => {
-    try {
-      await client.set('heartbeat', (Date.now() / 1e3).toFixed());
-    } catch (e) {
-      console.log('[redis] Heartbeat failed', e);
-    }
-  }, 10e3);
+  if (process.env.NODE_ENV !== 'test') {
+    setInterval(async () => {
+      try {
+        await client.set('heartbeat', (Date.now() / 1e3).toFixed());
+      } catch (e) {
+        console.log('[redis] Heartbeat failed', e);
+      }
+    }, 10e3);
+  }
 })();
 
 export default client;

--- a/test/.env.test
+++ b/test/.env.test
@@ -1,2 +1,3 @@
 HOST=http://localhost:3033
 NODE_ENV=test
+DATABASE_URL=redis://localhost:6379

--- a/test/integration/helpers/cache.test.ts
+++ b/test/integration/helpers/cache.test.ts
@@ -1,0 +1,35 @@
+import redis from '../../../src/redis';
+
+describe('cache', () => {
+  describe('getVp()', () => {
+    if (redis) {
+      afterAll(async () => {
+        await redis.quit();
+      });
+
+      describe('when cached', () => {
+        it.todo('returns the cached results');
+        it.todo('does not call the callback function');
+      });
+
+      describe('when not cached', () => {
+        it.todo('returns the live results');
+
+        describe('when the results should be cached', () => {
+          it.todo('caches the results when vp_state is final');
+          it.todo('does not cache the results when vp_state is not final');
+        });
+
+        describe('when the results should not be cached', () => {
+          it.todo('does not cache the results');
+        });
+      });
+
+      describe('when the cache engine is unavailable', () => {
+        it.todo('returns the live results');
+      });
+    } else {
+      it.todo('needs to set Redis credentials');
+    }
+  });
+});

--- a/test/integration/helpers/cache.test.ts
+++ b/test/integration/helpers/cache.test.ts
@@ -1,32 +1,103 @@
+import { cachedVp, VP_KEY_PREFIX } from '../../../src/helpers/cache';
 import redis from '../../../src/redis';
 
 describe('cache', () => {
   describe('getVp()', () => {
     if (redis) {
+      const key = 'test-vp-cache';
+      const hKey = `${VP_KEY_PREFIX}:${key}`;
+      const vp = {
+        vp: 1,
+        vp_by_strategy: [1],
+        vp_state: 'final'
+      };
+      const altVp = {
+        vp: 2,
+        vp_by_strategy: [3],
+        vp_state: 'final'
+      };
+      const mockedGetVp = jest.fn();
+      const callback = () => {
+        return mockedGetVp();
+      };
+      mockedGetVp.mockResolvedValue(vp);
+
       afterAll(async () => {
         await redis.quit();
+        jest.resetAllMocks();
+      });
+
+      afterEach(() => {
+        redis.del(`${VP_KEY_PREFIX}:${key}`);
       });
 
       describe('when cached', () => {
-        it.todo('returns the cached results');
-        it.todo('does not call the callback function');
+        let result;
+
+        beforeEach(() => {
+          const multi = redis.multi();
+          multi.hSet(hKey, 'vp', altVp.vp);
+          multi.hSet(hKey, 'vp_by_strategy', JSON.stringify(altVp.vp_by_strategy));
+          multi.hSet(hKey, 'vp_state', altVp.vp_state);
+          multi.exec();
+
+          result = cachedVp(key, callback);
+        });
+
+        it('returns the cached results', async () => {
+          await expect(result).resolves.toEqual({
+            result: altVp,
+            cache: true
+          });
+        });
+
+        it('does not call the callback function', () => {
+          expect(mockedGetVp).not.toHaveBeenCalled();
+        });
       });
 
       describe('when not cached', () => {
-        it.todo('returns the live results');
+        describe('when setting toCache to true', () => {
+          it('returns the live results', async () => {
+            await expect(cachedVp(key, callback, true)).resolves.toEqual({
+              result: vp,
+              cache: false
+            });
+            expect(mockedGetVp).toHaveBeenCalled();
+          });
 
-        describe('when the results should be cached', () => {
-          it.todo('caches the results when vp_state is final');
-          it.todo('does not cache the results when vp_state is not final');
+          it('caches the results when vp_state is final', async () => {
+            await cachedVp(key, callback, true);
+            await new Promise(resolve => setTimeout(resolve, 500));
+
+            expect(await redis.hGetAll(hKey)).toEqual({
+              vp: vp.vp.toString(),
+              vp_by_strategy: JSON.stringify(vp.vp_by_strategy),
+              vp_state: vp.vp_state
+            });
+            expect(mockedGetVp).toHaveBeenCalled();
+          });
+
+          it('does not cache the results when vp_state is not final', async () => {
+            mockedGetVp.mockResolvedValueOnce({ ...vp, vp_state: 'pending' });
+            await cachedVp(key, callback, true);
+            await new Promise(resolve => setTimeout(resolve, 500));
+            await expect(redis.exists(hKey)).resolves.toEqual(0);
+            expect(mockedGetVp).toHaveBeenCalled();
+          });
         });
 
-        describe('when the results should not be cached', () => {
-          it.todo('does not cache the results');
+        describe('when setting toCache to false', () => {
+          it('does not cache the results', async () => {
+            await expect(cachedVp(key, callback, false)).resolves.toEqual({
+              result: vp,
+              cache: false
+            });
+            await new Promise(resolve => setTimeout(resolve, 500));
+            await expect(redis.exists(hKey)).resolves.toEqual(0);
+            expect(mockedGetVp).toHaveBeenCalled();
+          });
         });
-      });
-
-      describe('when the cache engine is unavailable', () => {
-        it.todo('returns the live results');
       });
     } else {
       it.todo('needs to set Redis credentials');


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The cache engine is tightly coupled to the `getVp` function, making it harder to test and adding too much unrelated lines unrelated to the core function (almost half of the function's lines are related to cache set and get)

## 💊 Fixes / Solution

Extract the cache function from the `getVp` function.

The goal here is:

- to have a more simpler `getVp` function by removing the cache logic
- instrument the cache engine (in later PR), by tracking how many requests are hitting/missing/skipping the cache
- move the `getScores` to this cache engine in later PR, to benefit from instrumentation

## 🚧 Changes



## 🛠️ Tests

- Current tests are untouched, and pass
- run `yarn dev`
- run 
```bash
 curl 'http://localhost:3003/' \                                                              
  -H 'accept: application/json' \
  -H 'content-type: application/json' \
  --data-raw '{"jsonrpc":"2.0","method":"get_vp","params":{"address":"0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3","network":"42161","strategies":[{"name":"erc20-votes","network":"42161","params":{"symbol":"ARB","address":"0x912CE59144191C1204E64559FE8253a0e49E6548","decimals":18}}],"snapshot":143863052,"space":"arbitrumfoundation.eth","delegation":false}}' \
  --compressed
```
- it should return result with `cache: false` on first run
- it should return result with `cache: true` on subsequent run