### PR TITLE
fix: disable invalid spammy request to space

### DIFF
--- a/src/disabled.json
+++ b/src/disabled.json
@@ -1,1 +1,1 @@
-["revotu.eth", "aitd.eth", "benttest.eth"]
+["revotu.eth", "aitd.eth", "benttest.eth", "atayen.eth"]


### PR DESCRIPTION
Following https://discord.com/channels/955773041898573854/1031838169282392144/1184541211466399784

Disabling all requests to atayen.eth, as it's like 30% of total score-api requests, all failing