### PR TITLE
feat: make score-api turbo aware of turbo spaces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ AWS_REGION=
 AWS_SECRET_ACCESS_KEY=
 PORT=3003
 DATABASE_URL=redis://redis:6379
+HUB_URL=https://hub.snapshot.org
 # Keycard (Optional)
 KEYCARD_URL=https://keycard.snapshot.org
 KEYCARD_SECRET=

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@snapshot-labs/keycard": "0.5.1",
     "@snapshot-labs/snapshot-metrics": "^1.4.1",
     "@snapshot-labs/snapshot-sentry": "^1.5.4",
+    "@snapshot-labs/snapshot.js": "^0.10.1",
     "@snapshot-labs/strategies": "https://github.com/snapshot-labs/snapshot-strategies#master",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,12 @@
+import SpaceSchema from '@snapshot-labs/snapshot.js/src/schemas/space.json';
+
+const maxStrategiesWithSpaceType =
+  SpaceSchema.definitions.Space.properties.strategies.maxItemsWithSpaceType;
+
 export const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
-export const MAX_STRATEGIES = 10;
+export const MAX_STRATEGIES = {
+  default: maxStrategiesWithSpaceType['default'],
+  turbo: maxStrategiesWithSpaceType['turbo']
+};
 export const APP_NAME = 'score-api';
 export const AWS_CACHE_KEY = '4';

--- a/src/helpers/turbo.ts
+++ b/src/helpers/turbo.ts
@@ -1,0 +1,39 @@
+import snapshot from '@snapshot-labs/snapshot.js';
+import { capture } from '@snapshot-labs/snapshot-sentry';
+
+const HUB_URL = process.env.HUB_URL || 'https://hub.snapshot.org';
+
+export let turboSpaces: Set<string> = new Set();
+
+async function loadTurboSpaces(): Promise<boolean> {
+  const query = {
+    spaces: {
+      __args: {
+        where: {
+          turbo: true
+        }
+      },
+      id: true
+    }
+  };
+
+  try {
+    const response = await snapshot.utils.subgraphRequest(
+      `${HUB_URL}/graphql`,
+      query
+    );
+
+    turboSpaces = response.spaces.map(s => s.id);
+
+    return true;
+  } catch (e: any) {
+    capture(e);
+    return false;
+  }
+}
+
+export default async function run(): Promise<void> {
+  await loadTurboSpaces();
+  await snapshot.utils.sleep(60e3);
+  run();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,14 @@ import rpc from './rpc';
 import { rpcError } from './utils';
 import rateLimit from './helpers/rateLimit';
 import initMetrics from './metrics';
+import syncTurboSpaces from './helpers/turbo';
 
 const app = express();
 const PORT = process.env.PORT ?? 3003;
 
 initLogger(app);
 initMetrics(app);
+syncTurboSpaces();
 
 app.disable('x-powered-by');
 app.use(express.json({ limit: '8mb' }));

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -15,6 +15,7 @@ import disabled from './disabled.json';
 import serve from './requestDeduplicator';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import { EMPTY_ADDRESS, MAX_STRATEGIES } from './constants';
+import { turboSpaces } from './helpers/turbo';
 
 const router = express.Router();
 
@@ -43,7 +44,8 @@ router.post('/', async (req, res) => {
     if (
       !params.strategies ||
       params.strategies.length === 0 ||
-      params.strategies.length > MAX_STRATEGIES
+      params.strategies.length >
+        MAX_STRATEGIES[turboSpaces.has(params.space) ? 'turbo' : 'default']
     ) {
       return rpcError(res, 400, 'invalid strategies length', id);
     }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -259,8 +259,8 @@ describe('formatStrategies function', () => {
     expect(formattedStrategies).toHaveLength(2);
   });
 
-  it(`should limit strategies to ${MAX_STRATEGIES}`, () => {
-    const strategies = new Array(MAX_STRATEGIES + 1).fill({
+  it(`should limit strategies to ${MAX_STRATEGIES['default']} for default spaces`, () => {
+    const strategies = new Array(MAX_STRATEGIES['default'] + 1).fill({
       name: 'strategy',
       param: 'a'
     });
@@ -268,7 +268,21 @@ describe('formatStrategies function', () => {
 
     const formattedStrategies = formatStrategies(network, strategies);
 
-    expect(formattedStrategies).toHaveLength(MAX_STRATEGIES);
+    expect(formattedStrategies).toHaveLength(MAX_STRATEGIES['default']);
+  });
+
+  it(`should limit strategies to ${MAX_STRATEGIES['turbo']} for turbo spaces`, () => {
+    const strategies = new Array(MAX_STRATEGIES['turbo'] + 1).fill({
+      name: 'strategy',
+      param: 'a'
+    });
+    const network = 'defaultNetwork';
+
+    const formattedStrategies = formatStrategies(network, strategies, {
+      turbo: true
+    });
+
+    expect(formattedStrategies).toHaveLength(MAX_STRATEGIES['turbo']);
   });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,11 @@ function sortObjectByParam(obj) {
   return sortedObj;
 }
 
-export function formatStrategies(network, strategies: Array<any> = []) {
+export function formatStrategies(
+  network,
+  strategies: Array<any> = [],
+  options = { turbo: false }
+) {
   strategies = Array.isArray(strategies) ? strategies : [];
   // update strategy network, strategy parameters should be same order to maintain consistent key hashes and limit to max strategies
   return strategies
@@ -36,7 +40,7 @@ export function formatStrategies(network, strategies: Array<any> = []) {
       network: strategy?.network || network
     }))
     .map(sortObjectByParam)
-    .slice(0, MAX_STRATEGIES);
+    .slice(0, MAX_STRATEGIES[options.turbo ? 'turbo' : 'default']);
 }
 
 export function rpcSuccess(res, result, id, cache = false) {

--- a/test/e2e/get_vp.test.ts
+++ b/test/e2e/get_vp.test.ts
@@ -22,8 +22,12 @@ describe('getVp', () => {
       ['no strategies', null],
       ['empty strategies', []],
       [
-        'too many strategies',
-        Array(MAX_STRATEGIES + 1).fill({ name: 'test', param: 'a' })
+        'too many strategies for default spaces',
+        Array(MAX_STRATEGIES['default'] + 1).fill({ name: 'test', param: 'a' })
+      ],
+      [
+        'too many strategies for turbo spaces',
+        Array(MAX_STRATEGIES['turbo'] + 1).fill({ name: 'test', param: 'a' })
       ]
     ])('returns a 400 error on %s', async (title, strategies) => {
       const response = await request(process.env.HOST).post('/').send({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2089,6 +2089,26 @@
   dependencies:
     "@sentry/node" "^7.81.1"
 
+"@snapshot-labs/snapshot.js@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.10.1.tgz#d783ee394d6e3ad3d3a6e91fea67411752d15180"
+  integrity sha512-PacD8HdsYZhb1Yifp6n+11Og+nZUvGhTosu+ejnEwhP6zQOFMg6gaIEsWGjoAMnjos0sgA/oIbWdPIzqJRTECw==
+  dependencies:
+    "@ensdomains/eth-ens-namehash" "^2.0.15"
+    "@ethersproject/abi" "^5.6.4"
+    "@ethersproject/address" "^5.6.1"
+    "@ethersproject/bytes" "^5.6.1"
+    "@ethersproject/contracts" "^5.6.2"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/providers" "^5.6.8"
+    "@ethersproject/units" "^5.7.0"
+    "@ethersproject/wallet" "^5.6.2"
+    ajv "^8.11.0"
+    ajv-formats "^2.1.1"
+    cross-fetch "^3.1.6"
+    json-to-graphql-query "^2.2.4"
+    lodash.set "^4.3.2"
+
 "@snapshot-labs/snapshot.js@^0.9.9":
   version "0.9.9"
   resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.9.9.tgz#c7c7f8209129a38e50621aa325833ddd373b23e1"


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Score-api is not aware of turbo spaces, and is unable to limit the number of strategies for turbo and non-turbo spaces (currently, using the high turbo limit for everyone)

## 💊 Fixes / Solution

Depends on https://github.com/snapshot-labs/snapshot-hub/pull/789
Fix #1004 

This PR import a list of turbo spaces from the hub, which can be used to determine if a space is turbo or not.

## 🚧 Changes

- Add snapshot.js dependency
- Import list of turbo spaces ID from the hub (using snapshot.js `subgraphRequest` utils)
- Get max strategies count for default and turbo spaces from snapshot.js schema

## Limitation

There is no check to ensure whether the `space` params sent along the strategies are related to the strategies or not.
