### PR TITLE
fix: Check for invalid strategies

### DIFF
--- a/src/rpc.test.ts
+++ b/src/rpc.test.ts
@@ -33,7 +33,8 @@ jest.mock('./utils', () => ({
   }),
   rpcError: jest.fn((res, code) => {
     res.send(code);
-  })
+  }),
+  checkInvalidStrategies: jest.fn().mockReturnValue([])
 }));
 console.log = jest.fn();
 console.error = jest.fn();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import snapshot from '@snapshot-labs/strategies';
 import { createHash } from 'crypto';
 import { MAX_STRATEGIES } from './constants';
+import getStrategies from './helpers/strategies';
 
 const broviderUrl = process.env.BROVIDER_URL || 'https://rpc.snapshot.org';
 
@@ -37,6 +38,16 @@ export function formatStrategies(network, strategies: Array<any> = []) {
     }))
     .map(sortObjectByParam)
     .slice(0, MAX_STRATEGIES);
+}
+
+export function checkInvalidStrategies(strategies): Array<string> {
+  const strategyNames = strategies.map(strategy => strategy.name);
+  const snapshotStrategiesNames = Object.keys(getStrategies());
+  const invalidStrategies: Array<string> = strategyNames.filter(
+    s => s === undefined || !snapshotStrategiesNames.includes(s)
+  );
+
+  return [...new Set(invalidStrategies)];
 }
 
 export function rpcSuccess(res, result, id, cache = false) {


### PR DESCRIPTION
Right now we directly call strategies without checking if they exist, this PR will check for invalid strategies first