### PR TITLE
fix: remove the arbitrum dao proposal validation

### DIFF
--- a/src/helpers/validations.ts
+++ b/src/helpers/validations.ts
@@ -2,7 +2,7 @@ import snapshot from '@snapshot-labs/strategies';
 import { clone } from '../utils';
 
 let validationsCache;
-const hiddenValidations = ['passport-weighted'];
+const hiddenValidations = ['passport-weighted', 'arbitrum'];
 
 export default function getValidations() {
   if (validationsCache) {


### PR DESCRIPTION
Following https://discord.com/channels/955773041898573854/1031838169282392144/1343016499639750727

This PR is removing `arbitrum` from the valid proposal validation list

The validation is too dao specific, and used by 0 dao

### Test

1. Go to http://localhost:3003/api/validations
2. The list does not include arbitrum validation