### PR TITLE
feat: disable multichain strategy

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,3 +2,4 @@ export const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 export const MAX_STRATEGIES = 10;
 export const APP_NAME = 'score-api';
 export const AWS_CACHE_KEY = '5';
+export const DISABLED_STRATEGIES = ['multichain'];

--- a/src/helpers/strategies.ts
+++ b/src/helpers/strategies.ts
@@ -1,4 +1,5 @@
 import snapshot from '@snapshot-labs/strategies';
+import { DISABLED_STRATEGIES } from '../constants';
 import { clone } from '../utils';
 
 let strategiesCache;
@@ -9,11 +10,15 @@ export default function getStrategies() {
   }
 
   strategiesCache = Object.fromEntries(
-    Object.entries(clone(snapshot.strategies)).map(([key, strategy]) => [
-      key,
+    Object.entries(clone(snapshot.strategies)).map(([key, strategy]) => {
       // @ts-ignore
-      { key, ...strategy }
-    ])
+      const normalizedStrategy = { key, ...strategy };
+      if (DISABLED_STRATEGIES.includes(key)) {
+        normalizedStrategy.disabled = true;
+      }
+
+      return [key, normalizedStrategy];
+    })
   );
 
   return strategiesCache;


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/227

This PR adds a new `disabled` property to the strategies, to mark some strategies as disabled.

For now, only the `multichain` strategy is marked as disabled.

### Test

- Go to http://localhost:3003/api/strategies
- The multichain strategy has a `disabled: true` property