### PR TITLE
fix: add validation for strategies length in validate method

### DIFF
--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -89,6 +89,14 @@ router.post('/', async (req, res) => {
   }
 
   if (method === 'validate') {
+    if (
+      params.params?.strategies &&
+      (params.params.strategies.length === 0 ||
+        params.params.strategies.length > MAX_STRATEGIES)
+    ) {
+      return rpcError(res, 400, 'invalid strategies length', id);
+    }
+
     try {
       const result = await serve(JSON.stringify(params), validate, [params]);
       return rpcSuccess(res, result, id);


### PR DESCRIPTION
### Summary
- Better fix than https://github.com/snapshot-labs/snapshot-strategies/pull/1749/files (we can remove checks here)
- added check for strategies length in validate method, similar to `get_vp`
- return error if strategies length is invalid

### How to test

```bash
curl --location 'http://localhost:3003' \
--header 'Content-Type: application/json' \
--data '{
    "jsonrpc": "2.0",
    "method": "validate",
    "params": {
      "validation": "basic",
      "author": "0x662a9706c7122D620D410ba565CAfaB29e4CB47f",
      "space": "test.eth",
      "network": "1",
      "snapshot": "latest",
      "params": {
        "strategies": [
          {"name": "ticket", "network": "1", "params": {}},
          {"name": "ticket", "network": "1", "params": {}},
          {"name": "ticket", "network": "1", "params": {}},
          {"name": "ticket", "network": "1", "params": {}},
          {"name": "ticket", "network": "1", "params": {}},
          {"name": "ticket", "network": "1", "params": {}},
          {"name": "ticket", "network": "1", "params": {}},
          {"name": "ticket", "network": "1", "params": {}},
          {"name": "ticket", "network": "1", "params": {}},
          {"name": "ticket", "network": "1", "params": {}},
          {"name": "ticket", "network": "1", "params": {}}
        ]
      }
    }
  }'
  ```

  This should return `invalid strategies length` instead of `Max number of strategies exceeded`