### PR TITLE
chore: disable beacon-chain strategy and run lint action on pull request

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,6 @@
 name: Lint
 
 on:
-  push:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 name: Lint
 
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
 
 jobs:
   lint:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,9 @@
 name: Test
 
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
 
 jobs:
   test:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,6 @@
 name: Test
 
 on:
-  push:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 

--- a/src/strategies/strategies/beacon-chain/index.ts
+++ b/src/strategies/strategies/beacon-chain/index.ts
@@ -14,9 +14,12 @@ export async function strategy(
   _network,
   _provider,
   addresses: string[],
-  options,
-  _snapshot
+  options
+  // snapshot
 ): Promise<Record<string, number>> {
+  throw new Error(
+    'strategy is disabled because it is not using snapshot block'
+  );
   const {
     clEndpoint = 'https://rpc-gbc.gnosischain.com',
     clMultiplier = '32',
@@ -28,10 +31,13 @@ export async function strategy(
   try {
     const response = await customFetch(
       endpoint,
-      { headers: { accept: 'application/json', 'accept-encoding': 'gzip, br' } },
+      {
+        headers: { accept: 'application/json', 'accept-encoding': 'gzip, br' }
+      },
       80000
     );
-    if (!response.ok) throw new Error(`HTTP ${response.status} - ${response.statusText}`);
+    if (!response.ok)
+      throw new Error(`HTTP ${response.status} - ${response.statusText}`);
 
     const json: BeaconChainResponse = await response.json();
     const validators = json.data ?? [];
@@ -60,9 +66,10 @@ export async function strategy(
       const totalGwei = sumBySuffix.get(suffix) ?? 0n;
 
       const scaled = totalGwei === 0n ? 0n : totalGwei / multiplier;
-      result[original] = scaled === 0n
-        ? 0
-        : parseFloat(formatUnits(scaled.toString(), decimals));
+      result[original] =
+        scaled === 0n
+          ? 0
+          : parseFloat(formatUnits(scaled.toString(), decimals));
     }
 
     return result;


### PR DESCRIPTION
### Summary
looks like lint action is not triggered on PRs from external contributors, which made it hard to realize `snapshot` was not being used, so disabling this strategy for now  and fixing workflow


### Changes
- disable beacon-chain strategy for now (not using `snapshot` block)
- FIx lint
- update lint and test workflows for external contributors