### PR TITLE
refactor: remove deprecated 'delegation' parameter from request

### DIFF
--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -52,6 +52,9 @@ function handlePostError(
 router.post('/', async (req, res) => {
   const { id = null, method, params = {} } = req.body;
 
+  // The 'delegation' parameter is deprecated; requests should be treated identically whether or not it is present
+  if ('delegation' in params) delete params.delegation;
+
   if (params.space && disabled.includes(params.space))
     return rpcError(res, 429, 'too many requests', id);
 


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/workflow/issues/636


### Summary
Some integrators could still pass delegation param, which is considered as separate request, so we remove it from params

### How to test 
- Add a console.log here https://github.com/snapshot-labs/score-api/blob/fix-delegation-param/src/methods.ts#L69
- Try requests with both the delegation param and without the delegation param
- Example:
```
curl --location 'https://ideal-trout-g46p64gr5r7fvjgj-3003.app.github.dev/' \
--header 'accept: application/json' \
--data '{
    "jsonrpc": "2.0",
    "method": "get_vp",
    "params": {
        "address": "0x24F15402C6Bb870554489b2fd2049A85d75B982f",
        "strategies": [
            {
                "name": "ticket",
                "params": {
                }
            }
        ],
        "network": "1",
        "snapshot": 23203227,
        "delegation": false
    }
}'
```
Both requests should generate same key