### PR TITLE
fix: flag strategies as overriding

### DIFF
--- a/src/strategies/strategies/api-v2-override/manifest.json
+++ b/src/strategies/strategies/api-v2-override/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "API V2 Override",
   "author": "snapshot",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "overriding": true
 }

--- a/src/strategies/strategies/balance-of-with-linear-vesting-power/manifest.json
+++ b/src/strategies/strategies/balance-of-with-linear-vesting-power/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "Balance Of With Linear Vesting Power",
   "author": "morpho-labs",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "overriding": true
 }

--- a/src/strategies/strategies/cyberkongz-v2/manifest.json
+++ b/src/strategies/strategies/cyberkongz-v2/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "CyberKongz V2",
   "author": "frosti-eth",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "overriding": true
 }

--- a/src/strategies/strategies/erc20-balance-of-fixed-total/manifest.json
+++ b/src/strategies/strategies/erc20-balance-of-fixed-total/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "ERC-20 Balance Of Fixed Total",
   "author": "bonustrack",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "overriding": true
 }

--- a/src/strategies/strategies/erc20-balance-of-quadratic-delegation/manifest.json
+++ b/src/strategies/strategies/erc20-balance-of-quadratic-delegation/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "ERC-20 Balance Of Quadratic Delegation",
   "author": "ferittuncer",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "overriding": true
 }

--- a/src/strategies/strategies/erc20-votes-with-override/manifest.json
+++ b/src/strategies/strategies/erc20-votes-with-override/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "ERC-20 Votes With Override",
   "author": "serenae-fansubs",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "overriding": true
 }

--- a/src/strategies/strategies/ocean-dao-brightid/manifest.json
+++ b/src/strategies/strategies/ocean-dao-brightid/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "Ocean DAO BrightID",
   "author": "trizin",
-  "version": "0.2.0"
+  "version": "0.2.0",
+  "overriding": true
 }

--- a/src/strategies/strategies/orbs-network-delegation/manifest.json
+++ b/src/strategies/strategies/orbs-network-delegation/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "Orbs Network Delegation",
   "author": "gadcl",
-  "version": "0.1.2"
+  "version": "0.1.2",
+  "overriding": true
 }

--- a/src/strategies/strategies/split-delegation/manifest.json
+++ b/src/strategies/strategies/split-delegation/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "Split Delegation",
   "author": "gnosisguild",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "overriding": true
 }


### PR DESCRIPTION
This PR will flag some strategies as overriding, to be in sync with the list from sequencer:

https://github.com/snapshot-labs/snapshot-sequencer/blob/884d42154252357ce4ca1bba1392afdd3ca5e524/src/helpers/utils.ts#L67-L86

After this PR, we should now have 17 overriding strategies, a little less than the original sequencer list due to archived strategies

### Test

- Go to http://localhost:3003/api/strategies
- Search by `dependOnOtherAddress`
- It should return same strategies as in the list from sequencer above