### PR TITLE
fix: use own ipfs gateway

### DIFF
--- a/src/strategies/strategies/csv/index.ts
+++ b/src/strategies/strategies/csv/index.ts
@@ -11,7 +11,7 @@ async function parseCSV(
   fieldSeparator = ','
 ): Promise<Items> {
   if (url.startsWith('ipfs://')) {
-    url = url.replace('ipfs://', 'https://gateway.pinata.cloud/ipfs/');
+    url = url.replace('ipfs://', 'https://ipfs.snapshot.box/ipfs/');
   }
 
   const response = await fetch(url);


### PR DESCRIPTION
Pinata gateway is protected by cloudflare, failing the CSV fetching

This PR will update the `csv` strategy to use our own ipfs gateway

### Test

```
curl 'http://localhost:3003/' \
  -H 'accept: application/json' \
  -H 'content-type: application/json' \
  --data-raw '{"jsonrpc":"2.0","method":"get_vp","params":{"address":"0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3","space":"lightchain.ai","strategies":[{"name":"csv","network":"1","params":{"csv":"ipfs://bafybeicli45ntdazdcqaufn5tok6rsswg5g3ai2pvbcglelc7oab3oz76e","symbol":"LCAI","decimals":0}}],"network":"1","snapshot":"latest"}}'
```

It should return something instead of 500 error