### PR TITLE
update/aavegotchi-strategies-for-base

### DIFF
--- a/src/strategies/strategies/aavegotchi-agip-17/examples.json
+++ b/src/strategies/strategies/aavegotchi-agip-17/examples.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "AGIP 17: Voting power for GHST value of parcels",
+    "name": "AGIP 17: Voting power for GHST value of parcels (Polygon)",
     "strategy": {
       "name": "aavegotchi-agip-17",
       "params": {
@@ -14,5 +14,22 @@
       "0x585E06CA576D0565a035301819FD2cfD7104c1E8"
     ],
     "snapshot": 50601487
+  },
+  {
+    "name": "AGIP 17: Voting power for GHST value of parcels (Base)",
+    "strategy": {
+      "name": "aavegotchi-agip-17",
+      "params": {
+        "symbol": "REALM"
+      }
+    },
+    "network": "8453",
+    "addresses": [
+      "0x027Ffd3c119567e85998f4E6B9c3d83D5702660c",
+      "0xC3c2e1Cf099Bc6e1fA94ce358562BCbD5cc59FE5",
+      "0x585E06CA576D0565a035301819FD2cfD7104c1E8",
+      "0xAd0CEb6Dc055477b8a737B630D6210EFa76a2265"
+    ],
+    "snapshot": 34101946
   }
 ]

--- a/src/strategies/strategies/aavegotchi-agip-17/examples.json
+++ b/src/strategies/strategies/aavegotchi-agip-17/examples.json
@@ -1,21 +1,5 @@
 [
   {
-    "name": "AGIP 17: Voting power for GHST value of parcels (Polygon)",
-    "strategy": {
-      "name": "aavegotchi-agip-17",
-      "params": {
-        "symbol": "REALM"
-      }
-    },
-    "network": "137",
-    "addresses": [
-      "0x027Ffd3c119567e85998f4E6B9c3d83D5702660c",
-      "0xC3c2e1Cf099Bc6e1fA94ce358562BCbD5cc59FE5",
-      "0x585E06CA576D0565a035301819FD2cfD7104c1E8"
-    ],
-    "snapshot": 50601487
-  },
-  {
     "name": "AGIP 17: Voting power for GHST value of parcels (Base)",
     "strategy": {
       "name": "aavegotchi-agip-17",

--- a/src/strategies/strategies/aavegotchi-agip-17/index.ts
+++ b/src/strategies/strategies/aavegotchi-agip-17/index.ts
@@ -1,7 +1,6 @@
 import { subgraphRequest } from '../../utils';
 
 const AAVEGOTCHI_SUBGRAPH_URL = {
-  137: 'https://subgraph.satsuma-prod.com/tWYl5n5y04oz/aavegotchi/aavegotchi-core-matic/api',
   8453: 'https://subgraph.satsuma-prod.com/tWYl5n5y04oz/aavegotchi/aavegotchi-core-base/api'
 };
 

--- a/src/strategies/strategies/aavegotchi-agip-17/index.ts
+++ b/src/strategies/strategies/aavegotchi-agip-17/index.ts
@@ -1,7 +1,8 @@
 import { subgraphRequest } from '../../utils';
 
 const AAVEGOTCHI_SUBGRAPH_URL = {
-  137: 'https://subgraph.satsuma-prod.com/tWYl5n5y04oz/aavegotchi/aavegotchi-core-matic/api'
+  137: 'https://subgraph.satsuma-prod.com/tWYl5n5y04oz/aavegotchi/aavegotchi-core-matic/api',
+  8453: 'https://subgraph.satsuma-prod.com/tWYl5n5y04oz/aavegotchi/aavegotchi-core-base/api'
 };
 
 const maxResponsePerQuery = 1000;

--- a/src/strategies/strategies/aavegotchi-agip-17/manifest.json
+++ b/src/strategies/strategies/aavegotchi-agip-17/manifest.json
@@ -1,5 +1,5 @@
 {
   "name": "Aavegotchi AGIP 17",
-  "author": "candoizo",
-  "version": "0.1.2"
+  "author": "BromeRST",
+  "version": "0.2.0"
 }

--- a/src/strategies/strategies/aavegotchi-agip/examples.json
+++ b/src/strategies/strategies/aavegotchi-agip/examples.json
@@ -1,22 +1,5 @@
 [
   {
-    "name": "AGIP 8+9: Voting power for GHST value of items, their aavegotchis equippedWearables + baseRarityScore (Polygon)",
-    "strategy": {
-      "name": "aavegotchi-agip",
-      "params": {
-        "tokenAddress": "0x86935f11c86623dec8a25696e1c19a8659cbf95d",
-        "symbol": "GOTCHI"
-      }
-    },
-    "network": "137",
-    "addresses": [
-      "0x9730299b10A30bDbAF81815c99b4657c685314AB",
-      "0xDd564df884Fd4e217c9ee6F65B4BA6e5641eAC63",
-      "0xBfe09443556773958bae1699b786d8E9680B5571"
-    ],
-    "snapshot": 51370819
-  },
-  {
     "name": "AGIP 8+9: Voting power for GHST value of items, their aavegotchis equippedWearables + baseRarityScore (Base)",
     "strategy": {
       "name": "aavegotchi-agip",

--- a/src/strategies/strategies/aavegotchi-agip/examples.json
+++ b/src/strategies/strategies/aavegotchi-agip/examples.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "AGIP 8+9: Voting power for GHST value of items, their aavegotchis equippedWearables + baseRarityScore",
+    "name": "AGIP 8+9: Voting power for GHST value of items, their aavegotchis equippedWearables + baseRarityScore (Polygon)",
     "strategy": {
       "name": "aavegotchi-agip",
       "params": {
@@ -15,5 +15,22 @@
       "0xBfe09443556773958bae1699b786d8E9680B5571"
     ],
     "snapshot": 51370819
+  },
+  {
+    "name": "AGIP 8+9: Voting power for GHST value of items, their aavegotchis equippedWearables + baseRarityScore (Base)",
+    "strategy": {
+      "name": "aavegotchi-agip",
+      "params": {
+        "tokenAddress": "0xA99c4B08201F2913Db8D28e71d020c4298F29dBF",
+        "symbol": "GOTCHI"
+      }
+    },
+    "network": "8453",
+    "addresses": [
+      "0x9730299b10A30bDbAF81815c99b4657c685314AB",
+      "0xDd564df884Fd4e217c9ee6F65B4BA6e5641eAC63",
+      "0xBfe09443556773958bae1699b786d8E9680B5571"
+    ],
+    "snapshot": 33801946
   }
 ]

--- a/src/strategies/strategies/aavegotchi-agip/index.ts
+++ b/src/strategies/strategies/aavegotchi-agip/index.ts
@@ -5,7 +5,6 @@ interface Prices {
 }
 
 const AAVEGOTCHI_SUBGRAPH_URL = {
-  137: 'https://subgraph.satsuma-prod.com/tWYl5n5y04oz/aavegotchi/aavegotchi-core-matic/api',
   8453: 'https://subgraph.satsuma-prod.com/tWYl5n5y04oz/aavegotchi/aavegotchi-core-base/api'
 };
 
@@ -469,7 +468,7 @@ export async function strategy(
   }
 
   const subgraphRaw = await subgraphRequest(
-    AAVEGOTCHI_SUBGRAPH_URL[network],
+    AAVEGOTCHI_SUBGRAPH_URL[8453],
     query
   );
 

--- a/src/strategies/strategies/aavegotchi-agip/index.ts
+++ b/src/strategies/strategies/aavegotchi-agip/index.ts
@@ -5,7 +5,8 @@ interface Prices {
 }
 
 const AAVEGOTCHI_SUBGRAPH_URL = {
-  137: 'https://subgraph.satsuma-prod.com/tWYl5n5y04oz/aavegotchi/aavegotchi-core-matic/api'
+  137: 'https://subgraph.satsuma-prod.com/tWYl5n5y04oz/aavegotchi/aavegotchi-core-matic/api',
+  8453: 'https://subgraph.satsuma-prod.com/tWYl5n5y04oz/aavegotchi/aavegotchi-core-base/api'
 };
 
 enum GotchiRarityPrices {
@@ -468,7 +469,7 @@ export async function strategy(
   }
 
   const subgraphRaw = await subgraphRequest(
-    AAVEGOTCHI_SUBGRAPH_URL[137],
+    AAVEGOTCHI_SUBGRAPH_URL[network],
     query
   );
 

--- a/src/strategies/strategies/aavegotchi-agip/manifest.json
+++ b/src/strategies/strategies/aavegotchi-agip/manifest.json
@@ -1,5 +1,5 @@
 {
   "name": "Aavegotchi AGIP",
-  "author": "candoizo",
-  "version": "0.2.5"
+  "author": "BromeRST",
+  "version": "0.3.0"
 }

--- a/src/strategies/strategies/aavegotchi-wagmi-guild/examples.json
+++ b/src/strategies/strategies/aavegotchi-wagmi-guild/examples.json
@@ -1,22 +1,5 @@
 [
   {
-    "name": "Voting power based on aavegotchis equipped with wagie wearables for the WAGMI Warriors Guild (Polygon)",
-    "strategy": {
-      "name": "aavegotchi-wagmi-guild",
-      "params": {
-        "tokenAddress": "0x86935f11c86623dec8a25696e1c19a8659cbf95d",
-        "symbol": "GOTCHI"
-      }
-    },
-    "network": "137",
-    "addresses": [
-      "0x26cf02F892B04aF4Cf350539CE2C77FCF79Ec172",
-      "0x9730299b10A30bDbAF81815c99b4657c685314AB",
-      "0xDd564df884Fd4e217c9ee6F65B4BA6e5641eAC63"
-    ],
-    "snapshot": 20122217
-  },
-  {
     "name": "Voting power based on aavegotchis equipped with wagie wearables for the WAGMI Warriors Guild (Base)",
     "strategy": {
       "name": "aavegotchi-wagmi-guild",

--- a/src/strategies/strategies/aavegotchi-wagmi-guild/examples.json
+++ b/src/strategies/strategies/aavegotchi-wagmi-guild/examples.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "Voting power based on aavegotchis equipped with wagie wearables for the WAGMI Warriors Guild",
+    "name": "Voting power based on aavegotchis equipped with wagie wearables for the WAGMI Warriors Guild (Polygon)",
     "strategy": {
       "name": "aavegotchi-wagmi-guild",
       "params": {
@@ -9,7 +9,33 @@
       }
     },
     "network": "137",
-    "addresses": ["0x26cf02F892B04aF4Cf350539CE2C77FCF79Ec172"],
+    "addresses": [
+      "0x26cf02F892B04aF4Cf350539CE2C77FCF79Ec172",
+      "0x9730299b10A30bDbAF81815c99b4657c685314AB",
+      "0xDd564df884Fd4e217c9ee6F65B4BA6e5641eAC63"
+    ],
     "snapshot": 20122217
+  },
+  {
+    "name": "Voting power based on aavegotchis equipped with wagie wearables for the WAGMI Warriors Guild (Base)",
+    "strategy": {
+      "name": "aavegotchi-wagmi-guild",
+      "params": {
+        "tokenAddress": "0xA99c4B08201F2913Db8D28e71d020c4298F29dBF",
+        "symbol": "GOTCHI"
+      }
+    },
+    "network": "8453",
+    "addresses": [
+      "0x26cf02F892B04aF4Cf350539CE2C77FCF79Ec172",
+      "0x9730299b10A30bDbAF81815c99b4657c685314AB",
+      "0xDd564df884Fd4e217c9ee6F65B4BA6e5641eAC63",
+      "0xBfe09443556773958bae1699b786d8E9680B5571",
+      "0x027Ffd3c119567e85998f4E6B9c3d83D5702660c",
+      "0xC3c2e1Cf099Bc6e1fA94ce358562BCbD5cc59FE5",
+      "0x585E06CA576D0565a035301819FD2cfD7104c1E8",
+      "0xAd0CEb6Dc055477b8a737B630D6210EFa76a2265"
+    ],
+    "snapshot": 33801946
   }
 ]

--- a/src/strategies/strategies/aavegotchi-wagmi-guild/index.ts
+++ b/src/strategies/strategies/aavegotchi-wagmi-guild/index.ts
@@ -2,7 +2,6 @@ import { formatUnits } from '@ethersproject/units';
 import { subgraphRequest } from '../../utils';
 
 const AAVEGOTCHI_SUBGRAPH_URL = {
-  137: 'https://subgraph.satsuma-prod.com/tWYl5n5y04oz/aavegotchi/aavegotchi-core-matic/api',
   8453: 'https://subgraph.satsuma-prod.com/tWYl5n5y04oz/aavegotchi/aavegotchi-core-base/api'
 };
 

--- a/src/strategies/strategies/aavegotchi-wagmi-guild/index.ts
+++ b/src/strategies/strategies/aavegotchi-wagmi-guild/index.ts
@@ -2,7 +2,8 @@ import { formatUnits } from '@ethersproject/units';
 import { subgraphRequest } from '../../utils';
 
 const AAVEGOTCHI_SUBGRAPH_URL = {
-  137: 'https://subgraph.satsuma-prod.com/tWYl5n5y04oz/aavegotchi/aavegotchi-core-matic/api'
+  137: 'https://subgraph.satsuma-prod.com/tWYl5n5y04oz/aavegotchi/aavegotchi-core-matic/api',
+  8453: 'https://subgraph.satsuma-prod.com/tWYl5n5y04oz/aavegotchi/aavegotchi-core-base/api'
 };
 
 const itemPriceParams = {

--- a/src/strategies/strategies/aavegotchi-wagmi-guild/manifest.json
+++ b/src/strategies/strategies/aavegotchi-wagmi-guild/manifest.json
@@ -1,5 +1,5 @@
 {
   "name": "Aavegotchi WAGMI Guild",
-  "author": "programmablewealth",
-  "version": "0.1.0"
+  "author": "BromeRST",
+  "version": "0.2.0"
 }


### PR DESCRIPTION
It updates strategies to use base subgraphs and base chain ID instead of polygon