### PR TITLE
Fix Sablier v2 subgraph queries for recipient and sender streams

### DIFF
--- a/src/strategies/strategies/sablier-v2/configuration.ts
+++ b/src/strategies/strategies/sablier-v2/configuration.ts
@@ -147,9 +147,7 @@ type IAccountMap = Map<
 interface IStreamsByAssetResult {
   streams: {
     id: string;
-    contract: {
-      id: string;
-    };
+    contract: string;
     canceled: boolean;
     proxied: boolean;
     proxender: string;
@@ -177,14 +175,12 @@ const RecipientStreamsByAsset = ({
       orderDirection: 'desc',
       skip,
       where: {
-        asset,
+        asset_: { address: asset },
         recipient_in: accounts
       }
     },
     id: true,
-    contract: {
-      id: true
-    },
+    contract: true,
     canceled: true,
     recipient: true,
     sender: true,
@@ -212,18 +208,16 @@ const SenderStreamsByAsset = ({
       where: {
         or: [
           {
-            and: [{ asset: asset }, { sender_in: accounts }]
+            and: [{ asset_: { address: asset } }, { sender_in: accounts }]
           },
           {
-            and: [{ asset: asset }, { proxender_in: accounts }]
+            and: [{ asset_: { address: asset } }, { proxender_in: accounts }]
           }
         ]
       }
     },
     id: true,
-    contract: {
-      id: true
-    },
+    contract: true,
     canceled: true,
     proxied: true,
     proxender: true,

--- a/src/strategies/strategies/sablier-v2/examples.json
+++ b/src/strategies/strategies/sablier-v2/examples.json
@@ -4,113 +4,113 @@
     "strategy": {
       "name": "sablier-v2",
       "params": {
-        "address": "0x97cb342cf2f6ecf48c1285fb8668f5a4237bf862",
+        "address": "0x776b6fc2ed15d6bb5fc32e0c89de68683118c62a",
         "decimals": 18,
         "symbol": "DAI",
         "policy": "withdrawable-recipient"
       }
     },
-    "network": "5",
+    "network": "11155111",
     "addresses": [
       "0x9ad7cad4f10d0c3f875b8a2fd292590490c9f491",
       "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
       "0x506C56B2541eFeCf7A510E9A0c0382cB2FC69051"
     ],
-    "snapshot": 9455671
+    "snapshot": 9100000
   },
   {
     "name": "Example query with policy: deposited-recipient",
     "strategy": {
       "name": "sablier-v2",
       "params": {
-        "address": "0x97cb342cf2f6ecf48c1285fb8668f5a4237bf862",
+        "address": "0x776b6fc2ed15d6bb5fc32e0c89de68683118c62a",
         "decimals": 18,
         "symbol": "DAI",
         "policy": "deposited-recipient"
       }
     },
-    "network": "5",
+    "network": "11155111",
     "addresses": [
       "0x9ad7cad4f10d0c3f875b8a2fd292590490c9f491",
       "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
       "0x506C56B2541eFeCf7A510E9A0c0382cB2FC69051"
     ],
-    "snapshot": 9455671
+    "snapshot": 9100000
   },
   {
     "name": "Example query with policy: deposited-sender",
     "strategy": {
       "name": "sablier-v2",
       "params": {
-        "address": "0x97cb342cf2f6ecf48c1285fb8668f5a4237bf862",
+        "address": "0x776b6fc2ed15d6bb5fc32e0c89de68683118c62a",
         "decimals": 18,
         "symbol": "DAI",
         "policy": "deposited-sender"
       }
     },
-    "network": "5",
+    "network": "11155111",
     "addresses": [
       "0x9ad7cad4f10d0c3f875b8a2fd292590490c9f491",
       "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
       "0x506C56B2541eFeCf7A510E9A0c0382cB2FC69051"
     ],
-    "snapshot": 9455671
+    "snapshot": 9100000
   },
   {
     "name": "Example query with policy: streamed-recipient",
     "strategy": {
       "name": "sablier-v2",
       "params": {
-        "address": "0x97cb342cf2f6ecf48c1285fb8668f5a4237bf862",
+        "address": "0x776b6fc2ed15d6bb5fc32e0c89de68683118c62a",
         "decimals": 18,
         "symbol": "DAI",
         "policy": "streamed-recipient"
       }
     },
-    "network": "5",
+    "network": "11155111",
     "addresses": [
       "0x9ad7cad4f10d0c3f875b8a2fd292590490c9f491",
       "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
       "0x506C56B2541eFeCf7A510E9A0c0382cB2FC69051"
     ],
-    "snapshot": 9455671
+    "snapshot": 9100000
   },
   {
     "name": "Example query with policy: unstreamed-recipient",
     "strategy": {
       "name": "sablier-v2",
       "params": {
-        "address": "0x97cb342cf2f6ecf48c1285fb8668f5a4237bf862",
+        "address": "0x776b6fc2ed15d6bb5fc32e0c89de68683118c62a",
         "decimals": 18,
         "symbol": "DAI",
         "policy": "unstreamed-recipient"
       }
     },
-    "network": "5",
+    "network": "11155111",
     "addresses": [
       "0x9ad7cad4f10d0c3f875b8a2fd292590490c9f491",
       "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
       "0x506C56B2541eFeCf7A510E9A0c0382cB2FC69051"
     ],
-    "snapshot": 9455671
+    "snapshot": 9100000
   },
   {
     "name": "Example query with policy: reserved-recipient",
     "strategy": {
       "name": "sablier-v2",
       "params": {
-        "address": "0x97cb342cf2f6ecf48c1285fb8668f5a4237bf862",
+        "address": "0x776b6fc2ed15d6bb5fc32e0c89de68683118c62a",
         "decimals": 18,
         "symbol": "DAI",
         "policy": "reserved-recipient"
       }
     },
-    "network": "5",
+    "network": "11155111",
     "addresses": [
       "0x9ad7cad4f10d0c3f875b8a2fd292590490c9f491",
       "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
       "0x506C56B2541eFeCf7A510E9A0c0382cB2FC69051"
     ],
-    "snapshot": 9455671
+    "snapshot": 9100000
   }
 ]

--- a/src/strategies/strategies/sablier-v2/queries.ts
+++ b/src/strategies/strategies/sablier-v2/queries.ts
@@ -57,7 +57,7 @@ async function getRecipientStreams(
         const entry = {
           id: item.tokenId,
           canceled: item.canceled,
-          contract: item.contract.id,
+          contract: item.contract,
           deposited: item.depositAmount,
           withdrawn: item.withdrawnAmount
         };
@@ -128,7 +128,7 @@ async function getSenderStreams(
         const entry = {
           id: item.tokenId,
           canceled: item.canceled,
-          contract: item.contract.id,
+          contract: item.contract,
           deposited: item.depositAmount,
           withdrawn: item.withdrawnAmount
         };
@@ -451,12 +451,9 @@ async function getLatestBlock(
 
     if (snapshot === 'latest') {
       const endpoint = deployments[network].subgraph;
-      const name = endpoint.split('/subgraphs/name/')[1];
-      const url = new URL('https://api.thegraph.com/index-node/graphql');
+      const query = `{ _meta { block { number } } }`;
 
-      const query = `{indexingStatusForCurrentVersion(subgraphName: \"${name}\"){ chains { latestBlock { number }}}}`;
-
-      const response = await customFetch(url, {
+      const response = await customFetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ query }),
@@ -464,8 +461,7 @@ async function getLatestBlock(
       });
 
       const { data } = await response.json();
-      const block = data.indexingStatusForCurrentVersion.chains[0].latestBlock;
-      const result = Number(block.number);
+      const result = Number(data._meta.block.number);
 
       console.log('=== SABLIER V2 ===');
       console.log(`Fetched latest subgraph indexed block at {${result}}`);


### PR DESCRIPTION
### Summary  
Fix for Sablier v2 subgraph queries at Snapshot indexers for recipient and sender streams. 

### Motivation  
I wanted to use the Sablier v2 adapter in Snapshot, but quickly noticed that it did not show the correct values for active streams. Even when testing directly in the [Snapshot playground](https://testnet.v1.snapshot.box/#/playground/sablier-v2) on the Base Mainnet / Ethereum Sepolia network, the results were incorrect. In contrast, running the same query against the [Sablier-lockup-sepolia subgraph](https://api.studio.thegraph.com/query/112500/sablier-lockup-sepolia/version/latest/graphql?query=%7B%0A++streams%28%0A++++first%3A+10%0A++++skip%3A+0%0A++++orderBy%3A+timestamp%0A++++orderDirection%3A+desc%0A++++block%3A+%7Bnumber%3A+9100000%7D%0A++++where%3A+%7Bor%3A+%5B%7Band%3A+%5B%7Basset_%3A+%7Baddress%3A+%220x776b6fc2ed15d6bb5fc32e0c89de68683118c62a%22%7D%7D%2C+%7Bsender_in%3A+%5B%220x9ad7cad4f10d0c3f875b8a2fd292590490c9f491%22%2C+%220xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045%22%2C+%220x506C56B2541eFeCf7A510E9A0c0382cB2FC69051%22%5D%7D%5D%7D%2C+%7Band%3A+%5B%7Basset_%3A+%7Baddress%3A+%220x776b6fc2ed15d6bb5fc32e0c89de68683118c62a%22%7D%7D%2C+%7Bproxender_in%3A+%5B%220x9ad7cad4f10d0c3f875b8a2fd292590490c9f491%22%2C+%220xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045%22%2C+%220x506C56B2541eFeCf7A510E9A0c0382cB2FC69051%22%5D%7D%5D%7D%5D%7D%0A++%29+%7B%0A++++id%0A++++canceled%0A++++proxied%0A++++proxender%0A++++contract%0A++++recipient%0A++++sender%0A++++tokenId%0A++++depositAmount%0A++++withdrawnAmount%0A++%7D%0A%7D) returned the expected data.  

#### Screenshots
<img width="600" alt="image" src="https://github.com/user-attachments/assets/3dda3b0d-774e-44d0-9ece-455bd4f6e00e" />
<img width="800" alt="image" src="https://github.com/user-attachments/assets/d363cb63-10f9-4171-9b50-34338474a3db" />



I tried to find working examples and dug deeper into the adapter’s implementation. 
To validate the findings, I ran the Sablier v2 adapter test within the Snapshot repository. Along the way, I implemented fixes, such as correct handling recipient and sender streams from the Snapshot indexer and tests now pass successfully. 
Should work now in production, right?

---
### Running adapter test

```bash
yarn test:strategy sablier-v2
```
```
Test strategy "sablier-v2" with example index 0
    ✓ Strategy name should be lowercase and should not contain any special char expect hyphen (7 ms)
    ✓ Strategy name should be same as in examples.json (3 ms)
    ✓ Addresses in example should be minimum 3 and maximum 20 (4 ms)
    ✓ Must use a snapshot block number in the past (666 ms)
    ✓ Strategy should run without any errors (1440 ms)
    ✓ Should return an array of object with addresses (4 ms)
    ✓ Should take less than 10 sec. to resolve (1 ms)
    ✓ File examples.json should include at least 1 address with a positive score (1 ms)
    ✓ Returned addresses should be checksum addresses (2 ms)
    ✓ Voting power should not depend on other addresses (1079 ms)
  
Test strategy "sablier-v2" with example index 1
    ✓ Strategy name should be lowercase and should not contain any special char expect hyphen (1 ms)
    ✓ Strategy name should be same as in examples.json (1 ms)
    ✓ Addresses in example should be minimum 3 and maximum 20 (1 ms)
    ✓ Must use a snapshot block number in the past (208 ms)
    ✓ Strategy should run without any errors (487 ms)
    ✓ Should return an array of object with addresses (1 ms)
    ✓ Should take less than 10 sec. to resolve (1 ms)
    ✓ File examples.json should include at least 1 address with a positive score (1 ms)
    ✓ Returned addresses should be checksum addresses (1 ms)
    ✓ Voting power should not depend on other addresses (467 ms)
  
Test strategy "sablier-v2" with example index 2
    ✓ Strategy name should be lowercase and should not contain any special char expect hyphen (1 ms)
    ✓ Strategy name should be same as in examples.json (1 ms)
    ✓ Addresses in example should be minimum 3 and maximum 20 (1 ms)
    ✓ Must use a snapshot block number in the past (193 ms)
    ✓ Strategy should run without any errors (196 ms)
    ✓ Should return an array of object with addresses (2 ms)
    ✓ Should take less than 10 sec. to resolve
    ✓ File examples.json should include at least 1 address with a positive score
    ✓ Returned addresses should be checksum addresses (4 ms)
    ✓ Voting power should not depend on other addresses (400 ms)
  
Test strategy "sablier-v2" with example index 3
    ✓ Strategy name should be lowercase and should not contain any special char expect hyphen
    ✓ Strategy name should be same as in examples.json
    ✓ Addresses in example should be minimum 3 and maximum 20
    ✓ Must use a snapshot block number in the past (189 ms)
    ✓ Strategy should run without any errors (615 ms)
    ✓ Should return an array of object with addresses
    ✓ Should take less than 10 sec. to resolve
    ✓ File examples.json should include at least 1 address with a positive score
    ✓ Returned addresses should be checksum addresses (1 ms)
    ✓ Voting power should not depend on other addresses (783 ms)
  
Test strategy "sablier-v2" with example index 4
    ✓ Strategy name should be lowercase and should not contain any special char expect hyphen
    ✓ Strategy name should be same as in examples.json
    ✓ Addresses in example should be minimum 3 and maximum 20
    ✓ Must use a snapshot block number in the past (196 ms)
    ✓ Strategy should run without any errors (757 ms)
    ✓ Should return an array of object with addresses (1 ms)
    ✓ Should take less than 10 sec. to resolve
    ✓ File examples.json should include at least 1 address with a positive score
    ✓ Returned addresses should be checksum addresses (1 ms)
    ✓ Voting power should not depend on other addresses (612 ms)
  
Test strategy "sablier-v2" with example index 5
    ✓ Strategy name should be lowercase and should not contain any special char expect hyphen
    ✓ Strategy name should be same as in examples.json (1 ms)
    ✓ Addresses in example should be minimum 3 and maximum 20
    ✓ Must use a snapshot block number in the past (195 ms)
    ✓ Strategy should run without any errors (472 ms)
    ✓ Should return an array of object with addresses (2 ms)
    ✓ Should take less than 10 sec. to resolve (1 ms)
    ✓ File examples.json should include at least 1 address with a positive score (1 ms)
    ✓ Returned addresses should be checksum addresses (2 ms)
    ✓ Voting power should not depend on other addresses (499 ms)
  
Test strategy "sablier-v2" with example index 0 (latest snapshot)
    ✓ Strategy should run without any errors (1818 ms)
    ✓ Should return an array of object with addresses (2 ms)
  
Test strategy "sablier-v2" with example index 1 (latest snapshot)
    ✓ Strategy should run without any errors (1164 ms)
    ✓ Should return an array of object with addresses (2 ms)
  
Test strategy "sablier-v2" with example index 2 (latest snapshot)
    ✓ Strategy should run without any errors (1311 ms)
    ✓ Should return an array of object with addresses (1 ms)
  
Test strategy "sablier-v2" with example index 3 (latest snapshot)
    ✓ Strategy should run without any errors (1532 ms)
    ✓ Should return an array of object with addresses (2 ms)
  
Test strategy "sablier-v2" with example index 4 (latest snapshot)
    ✓ Strategy should run without any errors (1435 ms)
    ✓ Should return an array of object with addresses (1 ms)
  
Test strategy "sablier-v2" with example index 5 (latest snapshot)
    ✓ Strategy should run without any errors (1522 ms)
    ✓ Should return an array of object with addresses (12 ms)
  
Test strategy "sablier-v2" with example index 0 (with 500 addresses)
    ○ skipped Should work with 500 addresses
    ○ skipped Should take less than 20 sec. to resolve with 500 addresses
  
Test strategy "sablier-v2" with example index 1 (with 500 addresses)
    ○ skipped Should work with 500 addresses
    ○ skipped Should take less than 20 sec. to resolve with 500 addresses
  
Test strategy "sablier-v2" with example index 2 (with 500 addresses)
    ○ skipped Should work with 500 addresses
    ○ skipped Should take less than 20 sec. to resolve with 500 addresses
  
Test strategy "sablier-v2" with example index 3 (with 500 addresses)
    ○ skipped Should work with 500 addresses
    ○ skipped Should take less than 20 sec. to resolve with 500 addresses
  
Test strategy "sablier-v2" with example index 4 (with 500 addresses)
    ○ skipped Should work with 500 addresses
    ○ skipped Should take less than 20 sec. to resolve with 500 addresses
  
Test strategy "sablier-v2" with example index 5 (with 500 addresses)
    ○ skipped Should work with 500 addresses
    ○ skipped Should take less than 20 sec. to resolve with 500 addresses
  
Other tests with example index 0
    ✓ Check schema (if available) is valid with examples.json (14 ms)
    ✓ Check schema (if available) all arrays in all levels should contain `items` property (1 ms)
    ✓ Strategy should work even when strategy symbol is null (3 ms)
  
Other tests with example index 1
    ✓ Check schema (if available) is valid with examples.json (1 ms)
    ✓ Check schema (if available) all arrays in all levels should contain `items` property
    ✓ Strategy should work even when strategy symbol is null
  
Other tests with example index 2
    ✓ Check schema (if available) is valid with examples.json (1 ms)
    ✓ Check schema (if available) all arrays in all levels should contain `items` property (1 ms)
    ✓ Strategy should work even when strategy symbol is null (1 ms)
  
Other tests with example index 3
    ✓ Check schema (if available) is valid with examples.json (1 ms)
    ✓ Check schema (if available) all arrays in all levels should contain `items` property
    ✓ Strategy should work even when strategy symbol is null (1 ms)
  
Other tests with example index 4
    ✓ Check schema (if available) is valid with examples.json
    ✓ Check schema (if available) all arrays in all levels should contain `items` property
    ✓ Strategy should work even when strategy symbol is null (1 ms)
  
Other tests with example index 5
    ✓ Check schema (if available) is valid with examples.json
    ✓ Check schema (if available) all arrays in all levels should contain `items` property
    ✓ Strategy should work even when strategy symbol is null (1 ms)
  
Others:
    ✓ Author in strategy should be a valid github username (339 ms)
    ✓ Version in strategy should be a valid string

Test Suites: 1 passed, 1 total
Tests:       12 skipped, 92 passed, 104 total
Snapshots:   0 total
Time:        25.11 s
Ran all test suites matching /test\/strategies\/unit\/strategy.test.ts|sablier-v2/i.
```
---

### Working subgraph query (Ethereum Sepolia)
go to [Sablier-lockup-sepolia subgraph](https://api.studio.thegraph.com/query/112500/sablier-lockup-sepolia/version/latest/graphql?query=%7B%0A++streams%28%0A++++first%3A+10%0A++++skip%3A+0%0A++++orderBy%3A+timestamp%0A++++orderDirection%3A+desc%0A++++block%3A+%7Bnumber%3A+9100000%7D%0A++++where%3A+%7Bor%3A+%5B%7Band%3A+%5B%7Basset_%3A+%7Baddress%3A+%220x776b6fc2ed15d6bb5fc32e0c89de68683118c62a%22%7D%7D%2C+%7Bsender_in%3A+%5B%220x9ad7cad4f10d0c3f875b8a2fd292590490c9f491%22%2C+%220xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045%22%2C+%220x506C56B2541eFeCf7A510E9A0c0382cB2FC69051%22%5D%7D%5D%7D%2C+%7Band%3A+%5B%7Basset_%3A+%7Baddress%3A+%220x776b6fc2ed15d6bb5fc32e0c89de68683118c62a%22%7D%7D%2C+%7Bproxender_in%3A+%5B%220x9ad7cad4f10d0c3f875b8a2fd292590490c9f491%22%2C+%220xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045%22%2C+%220x506C56B2541eFeCf7A510E9A0c0382cB2FC69051%22%5D%7D%5D%7D%5D%7D%0A++%29+%7B%0A++++id%0A++++canceled%0A++++proxied%0A++++proxender%0A++++contract%0A++++recipient%0A++++sender%0A++++tokenId%0A++++depositAmount%0A++++withdrawnAmount%0A++%7D%0A%7D)
```
{
  streams(
    first: 10
    skip: 0
    orderBy: timestamp
    orderDirection: desc
    block: {number: 9100000}
    where: {
      or: [
        {and: [
          {asset_: {address: "0x776b6fc2ed15d6bb5fc32e0c89de68683118c62a"}}, 
          {sender_in: [
            "0x9ad7cad4f10d0c3f875b8a2fd292590490c9f491", 
            "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 
            "0x506C56B2541eFeCf7A510E9A0c0382cB2FC69051"
          ]}
        ]}, 
        {and: [
          {asset_: {address: "0x776b6fc2ed15d6bb5fc32e0c89de68683118c62a"}}, 
          {proxender_in: [
            "0x9ad7cad4f10d0c3f875b8a2fd292590490c9f491", 
            "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 
            "0x506C56B2541eFeCf7A510E9A0c0382cB2FC69051"
          ]}
        ]}
      ]}
  ) {
    id
    canceled
    proxied
    proxender
    contract
    recipient
    sender
    tokenId
    depositAmount
    withdrawnAmount
  }
}
```

---

### Changes  

**configuration.ts**  
- Updated `IStreamsByAssetResult` to store `contract` as a string instead of a nested object.  
- Adjusted GraphQL queries (`RecipientStreamsByAsset`, `SenderStreamsByAsset`) to:  
  - Use `asset_: { address: ... }` instead of `asset` for filtering.  
  - Request `contract` directly instead of nested `{ id }`.  

**examples.json**  
- Updated all example queries to:  
  - Use a new contract address (`0x776b6f...c62a`, `DAI`).  
  - Switch from Goerli (`network: "5"`) to Ethereum Sepolia (`network: "11155111"`).  
  - Adjust snapshot block number from `9455671` → `9100000`.

**queries.ts**  
- Changed `getRecipientStreams` and `getSenderStreams` to expect `contract` as a string instead of `contract.id`.  
- Simplified `getLatestBlock` query:  
  - Query `_meta { block { number } }` directly from the subgraph endpoint.

---

### References
[Snapshot Playground](https://testnet.v1.snapshot.box/#/playground/sablier-v2?query=eyJwYXJhbXMiOnsiYWRkcmVzcyI6IjB4OTdjYjM0MmNmMmY2ZWNmNDhjMTI4NWZiODY2OGY1YTQyMzdiZjg2MiIsImRlY2ltYWxzIjoxOCwic3ltYm9sIjoiREFJIiwicG9saWN5Ijoid2l0aGRyYXdhYmxlLXJlY2lwaWVudCJ9LCJzcGFjZSI6IiIsIm5ldHdvcmsiOiIxMTE1NTExMSIsInNuYXBzaG90IjoiOTEwMDAwMCIsImFkZHJlc3NlcyI6WyIweDlhZDdjYWQ0ZjEwZDBjM2Y4NzViOGEyZmQyOTI1OTA0OTBjOWY0OTEiLCIweGQ4ZEE2QkYyNjk2NGFGOUQ3ZUVkOWUwM0U1MzQxNUQzN2FBOTYwNDUiLCIweDUwNkM1NkIyNTQxZUZlQ2Y3QTUxMEU5QTBjMDM4MmNCMkZDNjkwNTEiXX0.)
[Sablier docs: Snapshot voting](https://docs.sablier.com/guides/snapshot-voting)
[Sablier docs: GraphQl schema](https://docs.sablier.com/api/lockup/graphql/schema#entities)
