### PR TITLE
chore(strategies): fix remaining formatted typo in pdn-balances-and-vests

### DIFF
--- a/src/strategies/strategies/pdn-balances-and-vests/index.ts
+++ b/src/strategies/strategies/pdn-balances-and-vests/index.ts
@@ -30,14 +30,14 @@ export async function strategy(
   const addressesWithVestLength: Record<string, BigNumberish> =
     await multi.execute();
 
-  const formatedAddressVests = Object.entries(addressesWithVestLength).reduce<
+  const formattedAddressVests = Object.entries(addressesWithVestLength).reduce<
     Record<string, number>
   >((acc, [addresses, vestLength]) => {
     acc[addresses] = Number(vestLength);
     return acc;
   }, {});
 
-  Object.entries(formatedAddressVests).forEach(([address, vestLength]) => {
+  Object.entries(formattedAddressVests).forEach(([address, vestLength]) => {
     if (vestLength > 0) {
       const vestIndexes = Array.from(Array(vestLength).keys());
 


### PR DESCRIPTION
Follow-up to #1478.

That PR cleaned up misspelled local variable names across four strategies (`multipler` → `multiplier`, `balFormatedData` → `balFormattedData`). While reviewing it, one more instance of the same typo turned up that wasn't covered: `formatedAddressVests` in the `pdn-balances-and-vests` strategy.

This PR fixes that last one, so the codebase is now free of the `multipler` / `formated` misspellings.

### Changes

`src/strategies/strategies/pdn-balances-and-vests/index.ts`

- `formatedAddressVests` → `formattedAddressVests` (2 occurrences: the declaration and its single use)

Local variable rename only. No behaviour change — strategy params, scoring logic and public API are all untouched.

## How to test

**Before**

```bash
git checkout master
grep -rn "multipler\|Formated\|formated" src/
# src/strategies/strategies/pdn-balances-and-vests/index.ts:33:  const formatedAddressVests = ...
# src/strategies/strategies/pdn-balances-and-vests/index.ts:40:  Object.entries(formatedAddressVests).forEach(...)
```

**After**

```bash
git checkout fix/pdn-formatted-typo
grep -rn "multipler\|Formated\|formated" src/
# (no matches)
```

**Checks**

```bash
yarn typecheck   # passes
yarn lint        # passes
yarn test:unit   # 131 passed, 2 skipped, 13 suites
```

The strategy itself scores identically before and after — the rename is confined to one function scope and there was no pre-existing `formattedAddressVests` binding to collide with.
