### PR TITLE
feat(validations): add useLatestBlock option to basic validation

### DIFF
--- a/src/strategies/validations/basic/examples.json
+++ b/src/strategies/validations/basic/examples.json
@@ -14,5 +14,22 @@
         }
       ]
     }
+  },
+  {
+    "name": "Example of a basic validation checking the latest block",
+    "author": "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7",
+    "space": "fabien.eth",
+    "network": "1",
+    "snapshot": 20000000,
+    "params": {
+      "minScore": 1,
+      "useLatestBlock": true,
+      "strategies": [
+        {
+          "name": "ticket",
+          "params": {}
+        }
+      ]
+    }
   }
 ]

--- a/src/strategies/validations/basic/index.ts
+++ b/src/strategies/validations/basic/index.ts
@@ -16,6 +16,8 @@ export default class extends Validation {
 
     if (!minScore) return true;
 
+    if (this.params.useLatestBlock) this.snapshot = 'latest';
+
     const scores = await getScoresDirect(
       this.space,
       this.params.strategies,

--- a/src/strategies/validations/basic/schema.json
+++ b/src/strategies/validations/basic/schema.json
@@ -37,6 +37,11 @@
             },
             "required": ["name", "params"]
           }
+        },
+        "useLatestBlock": {
+          "title": "Use latest block",
+          "description": "Check strategies against the current block instead of the proposal snapshot block. Useful for non-transferable tokens so users can vote right after minting.",
+          "type": "boolean"
         }
       },
       "required": ["minScore"],

--- a/test/strategies/integration/validation/basic.test.ts
+++ b/test/strategies/integration/validation/basic.test.ts
@@ -1,3 +1,4 @@
+import * as utils from '../../../../src/strategies/utils';
 import BasicValidation from '../../../../src/strategies/validations/basic';
 
 describe('Basic Validation Integration Tests', () => {
@@ -575,6 +576,58 @@ describe('Basic Validation Integration Tests', () => {
         const result = await validation.validate();
         expect(result).toBe(true);
       }, 30000);
+    });
+
+    describe('useLatestBlock', () => {
+      const author = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
+      const params = {
+        minScore: 1,
+        strategies: [{ name: 'whitelist', params: { addresses: [author] } }]
+      };
+      let getScoresDirectSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        getScoresDirectSpy = jest
+          .spyOn(utils, 'getScoresDirect')
+          .mockResolvedValue([{ [author]: 1 }]);
+      });
+
+      afterEach(() => {
+        getScoresDirectSpy.mockRestore();
+      });
+
+      it('should use the proposal snapshot by default', async () => {
+        validation = new BasicValidation(author, 'test-space', '1', 123456, {
+          ...params
+        });
+
+        await expect(validation.validate()).resolves.toBe(true);
+        expect(getScoresDirectSpy).toHaveBeenCalledWith(
+          'test-space',
+          params.strategies,
+          '1',
+          expect.anything(),
+          [author],
+          123456
+        );
+      });
+
+      it('should use the latest block when useLatestBlock is true', async () => {
+        validation = new BasicValidation(author, 'test-space', '1', 123456, {
+          ...params,
+          useLatestBlock: true
+        });
+
+        await expect(validation.validate()).resolves.toBe(true);
+        expect(getScoresDirectSpy).toHaveBeenCalledWith(
+          'test-space',
+          params.strategies,
+          '1',
+          expect.anything(),
+          [author],
+          'latest'
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
Context https://discord.com/channels/955773041898573854/1031838169282392144/1546508143364931644

Vote validation runs at the proposal's snapshot block, so anyone who mints a soulbound token after a proposal is created can't vote on it. This adds an opt-in `useLatestBlock` flag to the `basic` validation that checks the strategies at the current block instead, so users can verify → mint → vote right away.

- `basic/index.ts`: use `latest` when the flag is set.
- `basic/schema.json`: optional boolean, so the settings form shows a checkbox with no UI change.
- Example, version `0.3.0`, two jest cases.

Default behaviour unchanged. `validate` is never cached, so nothing to invalidate. Only for non-transferable tokens; applies to proposals created after enabling it. UI follow-up: snapshot-labs/sx-monorepo#2375.

## How to test

`yarn test:validation basic` and `npx jest test/strategies/integration/validation/basic.test.ts -t useLatestBlock --collectCoverage=false`.

Manual: POST `validate` (`basic`, old `snapshot`, `erc721` strategy) for an address that minted after that block. Before: `result: false`. With `"useLatestBlock": true` in `params`: `result: true`.
